### PR TITLE
remove sleep from set method in ModeStruct

### DIFF
--- a/adafruit_bno055.py
+++ b/adafruit_bno055.py
@@ -107,7 +107,6 @@ class _ModeStruct(Struct): # pylint: disable=too-few-public-methods
         obj.mode = self.mode
         super().__set__(obj, value)
         obj.mode = last_mode
-        time.sleep(0.01)
 
 class BNO055:
     """


### PR DESCRIPTION
as suggested in review, remove call to `sleep()` in the `_ModeStruct.__set__()` method